### PR TITLE
feat: add packed encoding

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -1,11 +1,7 @@
 //! Solidity bytes type.
 
 use crate::{
-    decode::{Decode, DecodeError, Decoder},
-    encode::{Encode, Encoder, Size},
-    fmt::Hex,
-    log::{FromTopic, ToTopic, TopicHash},
-    primitive::{Primitive, Word},
+    decode::{Decode, DecodeError, Decoder}, encode::{Encode, Encoder, Size}, encode_packed::EncodePacked, fmt::Hex, log::{FromTopic, ToTopic, TopicHash}, primitive::{Primitive, Word}
 };
 use ethprim::Hasher;
 use std::{
@@ -183,6 +179,18 @@ impl Encode for Bytes<&'_ [u8]> {
     fn encode(&self, encoder: &mut Encoder) {
         encoder.write(&self.len());
         encoder.write_bytes(self);
+    }
+}
+
+impl<T> EncodePacked for Bytes<T>
+where
+    T: AsRef<[u8]> + ?Sized,
+{
+    fn packed_size(&self) -> usize {
+        self.as_bytes().len()
+    }
+    fn encode_packed(&self, out: &mut [u8]) {
+        out[..self.as_bytes().len()].copy_from_slice(self.as_bytes());
     }
 }
 

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -1,7 +1,12 @@
 //! Solidity bytes type.
 
 use crate::{
-    decode::{Decode, DecodeError, Decoder}, encode::{Encode, Encoder, Size}, encode_packed::EncodePacked, fmt::Hex, log::{FromTopic, ToTopic, TopicHash}, primitive::{Primitive, Word}
+    decode::{Decode, DecodeError, Decoder},
+    encode::{Encode, Encoder, Size},
+    encode_packed::EncodePacked,
+    fmt::Hex,
+    log::{FromTopic, ToTopic, TopicHash},
+    primitive::{Primitive, Word},
 };
 use ethprim::Hasher;
 use std::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,7 +116,6 @@ pub mod constructor;
 pub mod decode;
 pub mod encode;
 pub mod packed;
-pub use self::packed::encode_packed;
 pub mod error;
 pub mod event;
 mod fmt;
@@ -143,6 +142,7 @@ pub mod prelude {
 pub use self::{
     decode::{decode, decode_with_prefix, decode_with_selector},
     encode::{encode, encode_to, encode_with_prefix, encode_with_selector},
+    packed::encode_packed,
     prelude::*,
 };
 pub use ethprim::{self, address, digest, int, keccak, uint};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,6 +115,7 @@ pub mod bytes;
 pub mod constructor;
 pub mod decode;
 pub mod encode;
+pub mod packed;
 pub mod error;
 pub mod event;
 mod fmt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,6 +116,7 @@ pub mod constructor;
 pub mod decode;
 pub mod encode;
 pub mod packed;
+pub use self::packed::encode_packed;
 pub mod error;
 pub mod event;
 mod fmt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,7 +180,10 @@ mod tests {
             uint!("42"),
             hex!("000000000000000000000000000000000000000000000000000000000000002a"),
         );
-        assert_eq!(encode_packed(&uint!("42")), hex!("000000000000000000000000000000000000000000000000000000000000002a"));
+        assert_eq!(
+            encode_packed(&uint!("42")),
+            hex!("000000000000000000000000000000000000000000000000000000000000002a")
+        );
     }
 
     #[test]
@@ -193,9 +196,7 @@ mod tests {
                  68656c6c6f000000000000000000000000000000000000000000000000000000"
             ),
         );
-        assert_eq!(encode_packed(&("hello".to_owned(),)), hex!(
-            "68656c6c6f"
-        ));
+        assert_eq!(encode_packed(&("hello".to_owned(),)), hex!("68656c6c6f"));
 
         assert_encoding!(
             "hello".to_owned(),
@@ -204,9 +205,7 @@ mod tests {
                  68656c6c6f000000000000000000000000000000000000000000000000000000"
             ),
         );
-        assert_eq!(encode_packed(&"hello".to_owned()), hex!(
-            "68656c6c6f"
-        ));
+        assert_eq!(encode_packed(&"hello".to_owned()), hex!("68656c6c6f"));
     }
 
     #[test]
@@ -236,22 +235,17 @@ mod tests {
             encode_packed(&(
                 291_i32,
                 vec![1110_i32, 1929_i32],
-                 Bytes(*b"1234567890"),
+                Bytes(*b"1234567890"),
                 "Hello, world!".to_owned(),
             )),
-            hex!(
-                "0000012300000456000007893132333435363738393048656c6c6f2c20776f726c6421"
-            ),
+            hex!("0000012300000456000007893132333435363738393048656c6c6f2c20776f726c6421"),
         );
 
         assert_encoding!(
             98127491_i32,
             hex!("0000000000000000000000000000000000000000000000000000000005d94e83"),
         );
-        assert_eq!(
-            encode_packed(&98127491_i32),
-            hex!("05d94e83"),
-        );
+        assert_eq!(encode_packed(&98127491_i32), hex!("05d94e83"),);
 
         assert_encoding!(
             (
@@ -268,9 +262,7 @@ mod tests {
                 324124_i32,
                 address!("0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826")
             )),
-            hex!(
-                "0004f21ccd2a3d9f938e13cd947ec05abc7fe734df8dd826"
-            ),
+            hex!("0004f21ccd2a3d9f938e13cd947ec05abc7fe734df8dd826"),
         );
     }
 
@@ -308,9 +300,7 @@ mod tests {
                 true,
                 address!(~"0xfffffffffffffffffffffffffffffffffffffffb")
             )),
-            hex!(
-                "0000000afffe00121212ffffffff1babab01fffffffffffffffffffffffffffffffffffffffb"
-            ),
+            hex!("0000000afffe00121212ffffffff1babab01fffffffffffffffffffffffffffffffffffffffb"),
         );
 
         assert_encoding!(
@@ -346,7 +336,7 @@ mod tests {
                     .to_owned(),
             )),
             hex!(
-               "616263646566
+                "616263646566
                 6162636465000000000000000000000000000000
                 616263646566616263646566676568616263616263617364666a6b6c61626364
                 6566616263656465666768616263616263617364666a6b6c6162636465666162
@@ -356,44 +346,22 @@ mod tests {
             ),
         );
 
-
         assert_encoding!(
             0_u8,
             hex!("0000000000000000000000000000000000000000000000000000000000000000"),
         );
-        assert_eq!(
-            encode_packed(&(
-                0_u8
-            )),
-            hex!(
-                "00"
-            ),
-        );
+        assert_eq!(encode_packed(&(0_u8)), hex!("00"),);
 
         assert_encoding!(
             1_u8,
             hex!("0000000000000000000000000000000000000000000000000000000000000001"),
         );
-        assert_eq!(
-            encode_packed(&(
-                1_u8
-            )),
-            hex!(
-                "01"
-            ),
-        );
+        assert_eq!(encode_packed(&(1_u8)), hex!("01"),);
         assert_encoding!(
             2_u8,
             hex!("0000000000000000000000000000000000000000000000000000000000000002"),
         );
-             assert_eq!(
-            encode_packed(&(
-                2_u8
-            )),
-            hex!(
-                "02"
-            ),
-        );
+        assert_eq!(encode_packed(&(2_u8)), hex!("02"),);
 
         assert_encoding!(
             (
@@ -422,9 +390,7 @@ mod tests {
                 -1_i8,
                 1_i8,
             )),
-            hex!(
-                "0000000af1f20000ffffff01"
-            ),
+            hex!("0000000af1f20000ffffff01"),
         );
 
         assert_encoding!(
@@ -449,9 +415,7 @@ mod tests {
                 vec![0xfffffffe_u64, 0xffffffff, 0x100000000],
                 11_i32
             )),
-            hex!(
-                "0000000a00000000fffffffe00000000ffffffff00000001000000000000000b"
-            ),
+            hex!("0000000a00000000fffffffe00000000ffffffff00000001000000000000000b"),
         );
 
         assert_encoding!(
@@ -472,12 +436,8 @@ mod tests {
             ),
         );
         assert_eq!(
-            encode_packed(&(
-                (10_i32, [vec![7_i16, 0x0506, -1], vec![4, 5]], 11_i32)
-            )),
-            hex!(
-                "0000000a00070506ffff000400050000000b"
-            ),
+            encode_packed(&((10_i32, [vec![7_i16, 0x0506, -1], vec![4, 5]], 11_i32))),
+            hex!("0000000a00070506ffff000400050000000b"),
         );
 
         assert_encoding!(
@@ -593,13 +553,11 @@ mod tests {
             ),
         );
         assert_eq!(
-            encode_packed(&(
-                vec![
-                    address!("0x0000000000000000000000000000000000000001"),
-                    address!("0x0000000000000000000000000000000000000002"),
-                    address!("0x0000000000000000000000000000000000000003"),
-                ],
-            )),
+            encode_packed(&(vec![
+                address!("0x0000000000000000000000000000000000000001"),
+                address!("0x0000000000000000000000000000000000000002"),
+                address!("0x0000000000000000000000000000000000000003"),
+            ],)),
             hex!(
                 "0000000000000000000000000000000000000001
                  0000000000000000000000000000000000000002
@@ -623,9 +581,7 @@ mod tests {
             ),
         );
         assert_eq!(
-            encode_packed(&(
-                vec![-1_i32, 2, -3, 4, -5, 6, -7, 8],
-            )),
+            encode_packed(&(vec![-1_i32, 2, -3, 4, -5, 6, -7, 8],)),
             hex!(
                 "ffffffff00000002fffffffd00000004fffffffb
                  00000006fffffff900000008"
@@ -648,7 +604,6 @@ mod tests {
                  001c08ab857afe5a9633887e7a4e2a429d1d8d42b3de648b0000000000000000"
             ),
         );
-        
 
         assert_encoding!(
             (
@@ -675,14 +630,7 @@ mod tests {
                  6162636465660000000000000000000000000000000000000000000000000000"
             ),
         );
-        assert_eq!(
-            encode_packed(&(
-                "abcdef".to_owned(),
-            )),
-            hex!(
-                "616263646566"
-            ),
-        );
+        assert_eq!(encode_packed(&("abcdef".to_owned(),)), hex!("616263646566"),);
         assert_encoding!(
             (
                 "abcdefgggggggggggggggggggggggggggggggggggggggghhheeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
@@ -698,7 +646,8 @@ mod tests {
         );
         assert_eq!(
             encode_packed(&(
-                "abcdefgggggggggggggggggggggggggggggggggggggggghhheeeeeeeeeeeeeeeeeeeeeeeeeeeeee".to_owned(),
+                "abcdefgggggggggggggggggggggggggggggggggggggggghhheeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+                    .to_owned(),
             )),
             hex!(
                 "6162636465666767676767676767676767676767676767676767676767676767
@@ -711,32 +660,17 @@ mod tests {
             0_i32,
             hex!("0000000000000000000000000000000000000000000000000000000000000000"),
         );
-        assert_eq!(
-            encode_packed(&0_i32),
-            hex!(
-                "00000000"
-            ),
-        );
+        assert_eq!(encode_packed(&0_i32), hex!("00000000"),);
         assert_encoding!(
             1_i32,
             hex!("0000000000000000000000000000000000000000000000000000000000000001"),
         );
-         assert_eq!(
-            encode_packed(&1_i32),
-            hex!(
-                "00000001"
-            ),
-        );
+        assert_eq!(encode_packed(&1_i32), hex!("00000001"),);
         assert_encoding!(
             7_i32,
             hex!("0000000000000000000000000000000000000000000000000000000000000007"),
         );
-        assert_eq!(
-            encode_packed(&7_i32),
-            hex!(
-                "00000007"
-            ),
-        );
+        assert_eq!(encode_packed(&7_i32), hex!("00000007"),);
 
         assert_encoding!(
             (
@@ -854,7 +788,11 @@ mod tests {
                 8_i32,
             )),
             hex!(
-                "00000007111111111111111111111111111111111111111100000011000000010000001200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000123400000000000000000000000000000021000000020000002200000000000000000000000000000008"
+                "0000000711111111111111111111111111111111111111110000001100000001
+                 0000001200000000000000000000000000000000000000000000000000000000
+                 0000000000000000000000000000000000000000000000000000000000001234
+                 0000000000000000000000000000002100000002000000220000000000000000
+                 0000000000000008"
             )
         );
 
@@ -875,7 +813,10 @@ mod tests {
                  0000000000000000000000000000000000000000000000000000000000000000"
             ),
         );
-        assert_eq!(encode_packed(&(vec![true, false, true, false], [true, false, true, false])), hex!("0100010001000100"));
+        assert_eq!(
+            encode_packed(&(vec![true, false, true, false], [true, false, true, false])),
+            hex!("0100010001000100")
+        );
 
         macro_rules! bytes_nn_arrays {
             ([$($size:literal),*] { $($nn:literal),* }) => {
@@ -978,7 +919,11 @@ mod tests {
                  0000000000000000000000000000000000000000000000000000000000000000"
             ),
         );
-        assert_eq!(encode_packed(&("".to_owned(), 3_i32, "".to_owned())), hex!("00000003"));
+        assert_eq!(
+            encode_packed(&("".to_owned(), 3_i32, "".to_owned())),
+            hex!("00000003")
+        );
+        assert_eq!(encode_packed(&("", 3_i32, "")), hex!("00000003"));
 
         assert_encoding!(
             ("abc".to_owned(), 7_i32, "def".to_owned()),
@@ -992,6 +937,9 @@ mod tests {
                  6465660000000000000000000000000000000000000000000000000000000000"
             ),
         );
-        assert_eq!(encode_packed(&("abc".to_owned(), 7_i32, "def".to_owned())), hex!("61626300000007646566"));
+        assert_eq!(
+            encode_packed(&("abc".to_owned(), 7_i32, "def".to_owned())),
+            hex!("61626300000007646566")
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -436,7 +436,7 @@ mod tests {
             ),
         );
         assert_eq!(
-            encode_packed(&((10_i32, [vec![7_i16, 0x0506, -1], vec![4, 5]], 11_i32))),
+            encode_packed(&(10_i32, [vec![7_i16, 0x0506, -1], vec![4, 5]], 11_i32)),
             hex!("0000000a00070506ffff000400050000000b"),
         );
 

--- a/src/packed.rs
+++ b/src/packed.rs
@@ -1,6 +1,8 @@
 //! Module implementing packed encoding.
 
-use crate::encode::BufferSizeError;
+
+use crate::encode::{BufferSizeError};
+use std::borrow::Cow;
 
 pub trait EncodePacked {
     fn encode_packed(&self, out: &mut [u8]);
@@ -47,7 +49,19 @@ impl_encode_packed_for_integer!(
     i8, i16, i32, i64, i128, isize,
 );
 
-impl<T, const N: usize> EncodePacked for [T; N]
+macro_rules! impl_encode_packed_for_ref {
+    () => {
+        fn packed_size(&self) -> usize {
+            (**self).packed_size()
+        }
+
+        fn encode_packed(&self, out: &mut [u8]) {
+            (**self).encode_packed(out)
+        }
+    };
+}
+
+impl<T> EncodePacked for [T]
 where
     T: EncodePacked,
 {
@@ -65,17 +79,130 @@ where
     }
 }
 
-macro_rules! impl_encode_packed_for_ref {
-    () => {
-        fn packed_size(&self) -> usize {
-            (**self).packed_size()
+impl<T, const N: usize> EncodePacked for [T; N]
+where
+    T: EncodePacked,
+{
+    fn packed_size(&self) -> usize {
+        self.as_slice().packed_size()
+    }
+
+    fn encode_packed(&self, out: &mut [u8]) {
+        self.as_slice().encode_packed(out)
+    }
+}
+
+
+impl<T, const N: usize> EncodePacked for &'_ [T; N]
+where
+    T: EncodePacked,
+{
+    impl_encode_packed_for_ref!();
+}
+
+impl<T> EncodePacked for Vec<T>
+where
+    T: EncodePacked,
+{
+    impl_encode_packed_for_ref!();
+}
+
+impl EncodePacked for str {
+    fn packed_size(&self) -> usize {
+        self.as_bytes().packed_size()
+    }
+
+    fn encode_packed(&self, out: &mut [u8]) {
+        self.as_bytes().encode_packed(out)
+    }
+}
+
+impl EncodePacked for &'_ str {
+    impl_encode_packed_for_ref!();
+}
+
+impl EncodePacked for String {
+    impl_encode_packed_for_ref!();
+}
+
+impl<T> EncodePacked for Cow<'_, T>
+where
+    T: EncodePacked + ToOwned + ?Sized,
+{
+    fn packed_size(&self) -> usize {
+        self.as_ref().packed_size()
+    }
+
+    fn encode_packed(&self, out: &mut [u8]) {
+        self.as_ref().encode_packed(out)
+    }
+}
+
+macro_rules! impl_encode_packed_for_tuple {
+    ($($t:ident),*) => {
+        #[allow(non_snake_case, unused_variables)]
+        impl<$($t),*> EncodePacked for ($($t,)*)
+        where
+            $($t: EncodePacked,)*
+        {
+            fn packed_size(&self) -> usize {
+                let ($($t,)*) = self;
+                0 $(+ $t.packed_size())*
+            }
+
+            fn encode_packed(&self, out: &mut [u8]) {
+                let ($($t,)*) = self;
+                let mut offset = 0;
+                $(
+                    let end = offset + $t.packed_size();
+                    $t.encode_packed(&mut out[offset..end]);
+                    offset = end;
+                )*
+            }
         }
 
-        fn encode_packed(&self, out: &mut [u8]) {
-            (**self).encode_packed(out)
+        impl<$($t),*> EncodePacked for &'_ ($($t,)*)
+        where
+            $($t: EncodePacked,)*
+        {
+            impl_encode_packed_for_ref!();
         }
     };
 }
+
+impl_encode_packed_for_tuple! {}
+impl_encode_packed_for_tuple! { A }
+impl_encode_packed_for_tuple! { A, B }
+impl_encode_packed_for_tuple! { A, B, C }
+impl_encode_packed_for_tuple! { A, B, C, D }
+impl_encode_packed_for_tuple! { A, B, C, D, E }
+impl_encode_packed_for_tuple! { A, B, C, D, E, F }
+impl_encode_packed_for_tuple! { A, B, C, D, E, F, G }
+impl_encode_packed_for_tuple! { A, B, C, D, E, F, G, H }
+impl_encode_packed_for_tuple! { A, B, C, D, E, F, G, H, I }
+impl_encode_packed_for_tuple! { A, B, C, D, E, F, G, H, I, J }
+impl_encode_packed_for_tuple! { A, B, C, D, E, F, G, H, I, J, K }
+impl_encode_packed_for_tuple! { A, B, C, D, E, F, G, H, I, J, K, L }
+impl_encode_packed_for_tuple! { A, B, C, D, E, F, G, H, I, J, K, L, M }
+impl_encode_packed_for_tuple! { A, B, C, D, E, F, G, H, I, J, K, L, M, N }
+impl_encode_packed_for_tuple! { A, B, C, D, E, F, G, H, I, J, K, L, M, N, O }
+impl_encode_packed_for_tuple! { A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P }
+impl_encode_packed_for_tuple! { A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q }
+impl_encode_packed_for_tuple! { A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R }
+impl_encode_packed_for_tuple! { A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S }
+impl_encode_packed_for_tuple! { A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T }
+impl_encode_packed_for_tuple! { A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U }
+impl_encode_packed_for_tuple! { A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V }
+impl_encode_packed_for_tuple! { A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W }
+impl_encode_packed_for_tuple! { A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X }
+impl_encode_packed_for_tuple! { A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y }
+impl_encode_packed_for_tuple! { A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z }
+impl_encode_packed_for_tuple! { A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA }
+impl_encode_packed_for_tuple! { A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB }
+impl_encode_packed_for_tuple! { A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC }
+impl_encode_packed_for_tuple! { A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD }
+impl_encode_packed_for_tuple! { A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE }
+impl_encode_packed_for_tuple! { A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF }
 
 #[cfg(test)]
 mod tests {
@@ -100,8 +227,14 @@ mod tests {
         assert_eq!(encode_packed(&-128i8), hex!("80"));
         assert_eq!(encode_packed(&127i8), hex!("7f"));
 
-        // Tests for array
-
+        // Tests for arra
         assert_eq!(encode_packed(&[1u8, 2, 3]), hex!("010203"));
+
+        // Tests for strings and variants
+        assert_eq!(encode_packed(&"hello"), hex!("68656c6c6f"));
+
+        // Tests for tuples
+        assert_eq!(encode_packed(&(1u8, 2u8)), hex!("0102"));
+        assert_eq!(encode_packed(&(1u8, 2u8, 3u8)), hex!("010203"));
     }
 }

--- a/src/packed.rs
+++ b/src/packed.rs
@@ -1,0 +1,46 @@
+//! Module implementing packed encoding.
+
+pub trait EncodePacked {
+    fn encode_packed(&self, out: &mut Vec<u8>);
+}
+
+pub fn encode_packed<T: EncodePacked>(value: &T) -> Vec<u8> {
+    let mut buf = Vec::new();
+    value.encode_packed(&mut buf);
+    buf
+}
+
+macro_rules! impl_encode_packed_for_integer {
+    ($($t:ty),* $(,)?) => {
+        $(
+            impl EncodePacked for $t {
+                fn encode_packed(&self, out: &mut Vec<u8>) {
+                    out.extend_from_slice(&self.to_be_bytes());
+                }
+            }
+        )*
+    };
+}
+
+impl_encode_packed_for_integer!(
+    u8, u16, u32, u64, u128, usize,
+    i8, i16, i32, i64, i128, isize,
+);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_basic_types() {
+        assert_eq!(encode_packed(&0u8), vec![0]);
+        assert_eq!(encode_packed(&255u8), vec![255]);
+        assert_eq!(encode_packed(&0x1234u16), vec![0x12, 0x34]);
+        assert_eq!(encode_packed(&0x01020304i32), vec![0x01, 0x02, 0x03, 0x04]);
+        assert_eq!(encode_packed(&-1i32), vec![0xff, 0xff, 0xff, 0xff]);
+        let encoded = encode_packed(&1usize);
+        assert!(encoded == vec![0, 0, 0, 1] || encoded == vec![0, 0, 0, 0, 0, 0, 0, 1]);
+        assert_eq!(encode_packed(&-128i8), vec![0x80]);
+        assert_eq!(encode_packed(&127i8), vec![0x7f]);
+    }
+}

--- a/src/packed.rs
+++ b/src/packed.rs
@@ -1,21 +1,41 @@
 //! Module implementing packed encoding.
 
+use crate::encode::BufferSizeError;
+
 pub trait EncodePacked {
-    fn encode_packed(&self, out: &mut Vec<u8>);
+    fn encode_packed(&self, out: &mut [u8]);
+
+    fn packed_size(&self) -> usize;
 }
 
 pub fn encode_packed<T: EncodePacked>(value: &T) -> Vec<u8> {
-    let mut buf = Vec::new();
-    value.encode_packed(&mut buf);
+    let mut buf = vec![0u8; value.packed_size()];
+    encode_packed_to(&mut buf, value).unwrap();
     buf
+}
+
+pub fn encode_packed_to<T>(buffer: &mut [u8], value: &T) -> Result<(), BufferSizeError>
+where
+    T: EncodePacked,
+{
+    if buffer.len() < value.packed_size() {
+        return Err(BufferSizeError);
+    }
+
+    value.encode_packed(buffer);
+    Ok(())
 }
 
 macro_rules! impl_encode_packed_for_integer {
     ($($t:ty),* $(,)?) => {
         $(
             impl EncodePacked for $t {
-                fn encode_packed(&self, out: &mut Vec<u8>) {
-                    out.extend_from_slice(&self.to_be_bytes());
+                fn encode_packed(&self, out: &mut [u8]) {
+                    out.copy_from_slice(&self.to_be_bytes());
+                }
+
+                fn packed_size(&self) -> usize {
+                    std::mem::size_of::<Self>()
                 }
             }
         )*
@@ -26,6 +46,23 @@ impl_encode_packed_for_integer!(
     u8, u16, u32, u64, u128, usize,
     i8, i16, i32, i64, i128, isize,
 );
+
+impl<T, const N: usize> EncodePacked for [T; N]
+where
+    T: EncodePacked,
+{
+    fn packed_size(&self) -> usize {
+        self.iter().map(|item| item.packed_size()).sum()
+    }
+
+    fn encode_packed(&self, out: &mut [u8]) {
+        let mut offset = 0;
+        for item in self {
+            item.encode_packed(&mut out[offset..offset + item.packed_size()]);
+            offset += item.packed_size();
+        }
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -42,5 +79,9 @@ mod tests {
         assert!(encoded == vec![0, 0, 0, 1] || encoded == vec![0, 0, 0, 0, 0, 0, 0, 1]);
         assert_eq!(encode_packed(&-128i8), vec![0x80]);
         assert_eq!(encode_packed(&127i8), vec![0x7f]);
+
+        // Tests for array
+
+        assert_eq!(encode_packed(&[1u8, 2, 3]), vec![1, 2, 3]);
     }
 }


### PR DESCRIPTION
As agreed in the [original issue](https://github.com/nlordell/solabi-rs/issues/7), I am first submitting a small PR with a proposal for the actual structure of packed encoding. Here is my process more or less:

1. I reviewed the Solidity documentation for both ABI encoding and packed encoding to ensure correctness.
2. I examined the existing Size, Primitive, Encode, and Encoder implementations in this crate.
3. I observed that the **ABI encoder uses a two-section (head/tail) buffer and preallocates the output array**, which is necessary for standard ABI encoding but not for packed encoding.
4. For **packed encoding**, since the **output is just a flat concatenation of bytes** (with no padding or alignment), we do not need the complexity of the ABI Encoder or the Size machinery.
5. To keep the initial implementation simple and efficient (especially since packed-encoded structures are typically small), I chose to use a **dynamically growing Vec<u8> as the output buffer**.
6. I implemented the core trait and macro for integer types, using their minimal big-endian byte representation, matching Solidity’s abi.encodePacked behavior.

In case performance ends up problematic, maybe I could switch it to preallocation, but this seemed really simple, since packed encoding is easier.

@nlordell @matevz @rube-de @abukosek

