### PR TITLE
Fix Cargo Clippy Lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,5 @@ ethprim = { version = "0.3", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 
 [dev-dependencies]
-hex-literal = "0.4"
+hex-literal = "1"
 serde_json = "1"

--- a/src/abi.rs
+++ b/src/abi.rs
@@ -45,7 +45,7 @@ pub struct FunctionDescriptor {
 
 impl FunctionDescriptor {
     /// Returns the error decriptor's canonical formatter.
-    pub fn canonical(&self) -> Canonical<Self> {
+    pub fn canonical(&self) -> Canonical<'_, Self> {
         Canonical(self)
     }
 
@@ -54,7 +54,7 @@ impl FunctionDescriptor {
     /// This is different than its canonical representation in that it also
     /// includes the return types. Function selectors are computed by hashing
     /// the canonical representation without the return types.
-    pub fn signature(&self) -> Signature {
+    pub fn signature(&self) -> Signature<'_> {
         Signature(self)
     }
 
@@ -97,7 +97,7 @@ pub struct EventDescriptor {
 
 impl EventDescriptor {
     /// Returns the error decriptor's canonical formatter.
-    pub fn canonical(&self) -> Canonical<Self> {
+    pub fn canonical(&self) -> Canonical<'_, Self> {
         Canonical(self)
     }
 
@@ -132,7 +132,7 @@ pub struct ErrorDescriptor {
 
 impl ErrorDescriptor {
     /// Returns the error decriptor's canonical formatter.
-    pub fn canonical(&self) -> Canonical<Self> {
+    pub fn canonical(&self) -> Canonical<'_, Self> {
         Canonical(self)
     }
 

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -176,7 +176,7 @@ impl TopicHash for Bytes<[u8]> {
 
 impl Encode for Bytes<&'_ [u8]> {
     fn size(&self) -> Size {
-        let words = (self.len() + 31) / 32;
+        let words = self.len().div_ceil(32);
         Size::Dynamic(1 + words, 0)
     }
 

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -249,7 +249,7 @@ impl Error for BufferSizeError {}
 
 /// Pads the specified size to a 32-byte boundry.
 fn pad32(value: usize) -> usize {
-    ((value + 31) / 32) * 32
+    value.div_ceil(32) * 32
 }
 
 /// Splits an array in-place returning a mutable slice to the chunk that was

--- a/src/event.rs
+++ b/src/event.rs
@@ -46,7 +46,7 @@ where
     }
 
     /// Encode event data into an EVM log.
-    pub fn encode(&self, indices: &I, data: &D) -> Log {
+    pub fn encode(&self, indices: &I, data: &D) -> Log<'_> {
         Log {
             topics: I::to_topics(&self.topic0, indices),
             data: crate::encode(data).into(),
@@ -87,7 +87,7 @@ where
     }
 
     /// Encode event data into an EVM log.
-    pub fn encode(&self, indices: &I, data: &D) -> Log {
+    pub fn encode(&self, indices: &I, data: &D) -> Log<'_> {
         Log {
             topics: I::to_topics_anonymous(indices),
             data: crate::encode(data).into(),

--- a/src/value.rs
+++ b/src/value.rs
@@ -729,7 +729,7 @@ impl Array {
 
     /// Creates a new array value from a vector of values.
     pub fn from_values(values: Vec<Value>) -> Option<Self> {
-        let element_kind = values.get(0)?.kind();
+        let element_kind = values.first()?.kind();
         Self::new(element_kind, values)
     }
 


### PR DESCRIPTION
The code was failing to lint with newer `cargo clippy` versions, so fix them!