### PR TITLE
Relax Encoder Bounds

### DIFF
--- a/src/constructor.rs
+++ b/src/constructor.rs
@@ -20,7 +20,6 @@ pub struct ConstructorEncoder<B, P> {
 impl<B, P> ConstructorEncoder<B, P>
 where
     B: AsRef<[u8]>,
-    P: Encode + Decode,
 {
     /// Creates a new constructor encoder from a selector.
     pub const fn new(code: B) -> Self {
@@ -29,7 +28,13 @@ where
             _marker: PhantomData,
         }
     }
+}
 
+impl<B, P> ConstructorEncoder<B, P>
+where
+    B: AsRef<[u8]>,
+    P: Encode,
+{
     /// Encodes a contract deployment for the specified parameters.
     pub fn encode(&self, data: &P) -> Vec<u8> {
         crate::encode_with_prefix(self.code.as_ref(), data)
@@ -39,7 +44,13 @@ where
     pub fn encode_params(&self, data: &P) -> Vec<u8> {
         crate::encode(data)
     }
+}
 
+impl<B, P> ConstructorEncoder<B, P>
+where
+    B: AsRef<[u8]>,
+    P: Decode,
+{
     /// Decodes the contract deployment parameters from the specified calldata.
     pub fn decode(&self, data: &[u8]) -> Result<P, DecodeError> {
         crate::decode_with_prefix(self.code.as_ref(), data)

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,10 +17,7 @@ pub struct ErrorEncoder<D> {
     _marker: PhantomData<*const D>,
 }
 
-impl<D> ErrorEncoder<D>
-where
-    D: Encode + Decode,
-{
+impl<D> ErrorEncoder<D> {
     /// Creates a new error encoder from a selector.
     pub const fn new(selector: Selector) -> Self {
         Self {
@@ -28,12 +25,22 @@ where
             _marker: PhantomData,
         }
     }
+}
 
+impl<D> ErrorEncoder<D>
+where
+    D: Encode,
+{
     /// Encodes a Solidity error for the specified data.
     pub fn encode(&self, data: &D) -> Vec<u8> {
         crate::encode_with_selector(self.selector, data)
     }
+}
 
+impl<D> ErrorEncoder<D>
+where
+    D: Decode,
+{
     /// Decodes a Solidity error from the return bytes call into its data.
     pub fn decode(&self, data: &[u8]) -> Result<D, DecodeError> {
         crate::decode_with_selector(self.selector, data)

--- a/src/event.rs
+++ b/src/event.rs
@@ -35,7 +35,6 @@ pub struct EventEncoder<I, D> {
 impl<I, D> EventEncoder<I, D>
 where
     I: Indexed,
-    D: Encode + Decode,
 {
     /// Creates a new typed event from a topic0.
     pub const fn new(topic0: Word) -> Self {
@@ -44,7 +43,13 @@ where
             _marker: PhantomData,
         }
     }
+}
 
+impl<I, D> EventEncoder<I, D>
+where
+    I: Indexed,
+    D: Encode,
+{
     /// Encode event data into an EVM log.
     pub fn encode(&self, indices: &I, data: &D) -> Log<'_> {
         Log {
@@ -52,7 +57,13 @@ where
             data: crate::encode(data).into(),
         }
     }
+}
 
+impl<I, D> EventEncoder<I, D>
+where
+    I: Indexed,
+    D: Decode,
+{
     /// Decode event data from an EVM log.
     pub fn decode(&self, log: &Log) -> Result<(I, D), ParseError> {
         let (topic0, indices) = I::from_topics(&log.topics)?;
@@ -79,13 +90,18 @@ pub struct AnonymousEventEncoder<I, D>(PhantomData<*const (I, D)>);
 impl<I, D> AnonymousEventEncoder<I, D>
 where
     I: IndexedAnonymous,
-    D: Encode + Decode,
 {
     /// Creates a new anonymous event.
     pub fn new() -> Self {
         Self(PhantomData)
     }
+}
 
+impl<I, D> AnonymousEventEncoder<I, D>
+where
+    I: IndexedAnonymous,
+    D: Encode,
+{
     /// Encode event data into an EVM log.
     pub fn encode(&self, indices: &I, data: &D) -> Log<'_> {
         Log {
@@ -93,7 +109,13 @@ where
             data: crate::encode(data).into(),
         }
     }
+}
 
+impl<I, D> AnonymousEventEncoder<I, D>
+where
+    I: IndexedAnonymous,
+    D: Decode,
+{
     /// Decode event data from an EVM log.
     pub fn decode(&self, log: &Log) -> Result<(I, D), ParseError> {
         let indices = I::from_topics_anonymous(&log.topics)?;
@@ -106,7 +128,6 @@ where
 impl<I, D> Debug for AnonymousEventEncoder<I, D>
 where
     I: IndexedAnonymous,
-    D: Encode + Decode,
 {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         f.debug_tuple("AnonymousEventEncoder").finish()
@@ -116,7 +137,6 @@ where
 impl<I, D> Default for AnonymousEventEncoder<I, D>
 where
     I: IndexedAnonymous,
-    D: Encode + Decode,
 {
     fn default() -> Self {
         Self::new()

--- a/src/function.rs
+++ b/src/function.rs
@@ -103,11 +103,7 @@ pub struct FunctionEncoder<P, R> {
     _marker: PhantomData<*const (P, R)>,
 }
 
-impl<P, R> FunctionEncoder<P, R>
-where
-    P: Encode + Decode,
-    R: Encode + Decode,
-{
+impl<P, R> FunctionEncoder<P, R> {
     /// Creates a new function encoder from a selector.
     pub const fn new(selector: Selector) -> Self {
         Self {
@@ -115,22 +111,42 @@ where
             _marker: PhantomData,
         }
     }
+}
 
+impl<P, R> FunctionEncoder<P, R>
+where
+    P: Encode,
+{
     /// Encodes a function call for the specified parameters.
     pub fn encode_params(&self, params: &P) -> Vec<u8> {
         crate::encode_with_selector(self.selector, params)
     }
+}
 
+impl<P, R> FunctionEncoder<P, R>
+where
+    P: Decode,
+{
     /// Decodes a function call into its parameters.
     pub fn decode_params(&self, data: &[u8]) -> Result<P, DecodeError> {
         crate::decode_with_selector(self.selector, data)
     }
+}
 
+impl<P, R> FunctionEncoder<P, R>
+where
+    R: Encode,
+{
     /// Encodes function return data.
     pub fn encode_returns(&self, returns: &R) -> Vec<u8> {
         crate::encode(returns)
     }
+}
 
+impl<P, R> FunctionEncoder<P, R>
+where
+    R: Decode,
+{
     /// Decodes function return data.
     pub fn decode_returns(&self, data: &[u8]) -> Result<R, DecodeError> {
         crate::decode(data)


### PR DESCRIPTION
This PR modifies the `Encode + Decode` bounds on parameter types for the various encoders, allowing one to implement _just_ the trait that is needed on special types.

For example, if you implement `Encode` for a custom type for ABI-encoding funtion parameters, and never try to decode the function parameter, then you can still use it with the `FunctionEncoder` type.