### PR TITLE
Add Missing `EncodePacked` Implementations

### DIFF
--- a/src/bitint.rs
+++ b/src/bitint.rs
@@ -3,7 +3,10 @@
 //! These types are needed because there aren't Rust equivalents for all
 //! Solidity integer types (`int96` for example).
 
-use crate::primitive::{Primitive, Word};
+use crate::{
+    encode_packed::EncodePacked,
+    primitive::{Primitive, Word},
+};
 use ethprim::{I256, U256};
 use std::{
     error::Error,
@@ -76,6 +79,17 @@ macro_rules! impl_bitint {
 
             fn from_word(word: Word) -> Self {
                 Self::new_truncated(<$i>::from_word(word))
+            }
+        }
+
+        impl EncodePacked for $t {
+            fn packed_size(&self) -> usize {
+                $n / 8
+            }
+
+            fn encode_packed(&self, out: &mut [u8]) {
+                const OFFSET: usize = mem::size_of::<$i>() - ($n / 8);
+                out.copy_from_slice(&self.0.to_be_bytes()[OFFSET..])
             }
         }
 
@@ -167,6 +181,7 @@ impl_bitint! {
     impl Int208 <signed 208> (I256);
     impl Int216 <signed 216> (I256);
     impl Int224 <signed 224> (I256);
+    impl Int232 <signed 232> (I256);
     impl Int240 <signed 240> (I256);
     impl Int248 <signed 248> (I256);
     impl Uint24 <unsigned 24> (u32);
@@ -192,6 +207,7 @@ impl_bitint! {
     impl Uint208 <unsigned 208> (U256);
     impl Uint216 <unsigned 216> (U256);
     impl Uint224 <unsigned 224> (U256);
+    impl Uint232 <unsigned 232> (U256);
     impl Uint240 <unsigned 240> (U256);
     impl Uint248 <unsigned 248> (U256);
 }

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -130,7 +130,7 @@ impl ToOwned for Bytes<[u8]> {
     }
 }
 
-macro_rules! impl_primitive_for_fixed_bytes {
+macro_rules! impl_fixed_bytes {
     ($($n:literal,)*) => {$(
         impl Primitive for Bytes<[u8; $n]> {
             fn to_word(&self) -> Word {
@@ -145,10 +145,20 @@ macro_rules! impl_primitive_for_fixed_bytes {
                 bytes
             }
         }
+
+        impl EncodePacked for Bytes<[u8; $n]> {
+            fn packed_size(&self) -> usize {
+                $n
+            }
+
+            fn encode_packed(&self, out: &mut [u8]) {
+                out.copy_from_slice(self.as_ref())
+            }
+        }
     )*};
 }
 
-impl_primitive_for_fixed_bytes! {
+impl_fixed_bytes! {
      1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16,
     17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
 }
@@ -160,6 +170,16 @@ impl Encode for Bytes<[u8]> {
 
     fn encode(&self, encoder: &mut Encoder) {
         Bytes(&self.0).encode(encoder)
+    }
+}
+
+impl EncodePacked for Bytes<[u8]> {
+    fn packed_size(&self) -> usize {
+        Bytes(&self.0).packed_size()
+    }
+
+    fn encode_packed(&self, out: &mut [u8]) {
+        Bytes(&self.0).encode_packed(out)
     }
 }
 
@@ -187,15 +207,13 @@ impl Encode for Bytes<&'_ [u8]> {
     }
 }
 
-impl<T> EncodePacked for Bytes<T>
-where
-    T: AsRef<[u8]> + ?Sized,
-{
+impl EncodePacked for Bytes<&'_ [u8]> {
     fn packed_size(&self) -> usize {
-        self.as_bytes().len()
+        self.len()
     }
+
     fn encode_packed(&self, out: &mut [u8]) {
-        out[..self.as_bytes().len()].copy_from_slice(self.as_bytes());
+        out.copy_from_slice(self);
     }
 }
 
@@ -224,6 +242,16 @@ impl Encode for Bytes<Vec<u8>> {
 
     fn encode(&self, encoder: &mut Encoder) {
         Bytes(&self[..]).encode(encoder)
+    }
+}
+
+impl EncodePacked for Bytes<Vec<u8>> {
+    fn packed_size(&self) -> usize {
+        Bytes(&self[..]).packed_size()
+    }
+
+    fn encode_packed(&self, out: &mut [u8]) {
+        Bytes(&self[..]).encode_packed(out)
     }
 }
 

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -337,11 +337,11 @@ where
     T: Encode,
 {
     fn size(&self) -> Size {
-        (**self).size()
+        self.as_slice().size()
     }
 
     fn encode(&self, encoder: &mut Encoder) {
-        (**self).encode(encoder)
+        self.as_slice().encode(encoder)
     }
 }
 
@@ -361,11 +361,11 @@ impl Encode for &'_ str {
 
 impl Encode for String {
     fn size(&self) -> Size {
-        (**self).size()
+        self.as_str().size()
     }
 
     fn encode(&self, encoder: &mut Encoder) {
-        (**self).encode(encoder)
+        self.as_str().encode(encoder)
     }
 }
 

--- a/src/function.rs
+++ b/src/function.rs
@@ -3,6 +3,7 @@
 use crate::{
     decode::{Decode, DecodeError},
     encode::Encode,
+    encode_packed::EncodePacked,
     fmt::Hex,
     primitive::{Primitive, Word},
 };
@@ -93,6 +94,17 @@ impl Primitive for ExternalFunction {
         address.copy_from_slice(&word[..20]);
         selector.0.copy_from_slice(&word[20..24]);
         Self { address, selector }
+    }
+}
+
+impl EncodePacked for ExternalFunction {
+    fn packed_size(&self) -> usize {
+        24
+    }
+
+    fn encode_packed(&self, out: &mut [u8]) {
+        out[..20].copy_from_slice(self.address.as_ref());
+        out[20..].copy_from_slice(self.selector.as_ref());
     }
 }
 

--- a/src/primitive.rs
+++ b/src/primitive.rs
@@ -74,7 +74,7 @@ impl Primitive for bool {
 impl Primitive for Address {
     fn to_word(&self) -> Word {
         let mut word = Word::default();
-        word[12..].copy_from_slice(&**self);
+        word[12..].copy_from_slice(self.as_ref());
         word
     }
 


### PR DESCRIPTION
Added some missing `EncodePacked` implementations and changed the testing to always test both regular and packed encoding (to make sure we cover all the types).

Additionally, I added tests for encoding of Solidity bitint types.