### PR TITLE
Strict ABI Decoding

### DIFF
--- a/src/bitint.rs
+++ b/src/bitint.rs
@@ -77,8 +77,8 @@ macro_rules! impl_bitint {
                 self.0.to_word()
             }
 
-            fn from_word(word: Word) -> Self {
-                Self::new_truncated(<$i>::from_word(word))
+            fn from_word(word: Word) -> Option<Self> {
+                Self::new(<$i>::from_word(word)?)
             }
         }
 

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -139,10 +139,13 @@ macro_rules! impl_fixed_bytes {
                 word
             }
 
-            fn from_word(word: Word) -> Self {
+            fn from_word(word: Word) -> Option<Self> {
+                if word[$n..] != [0; 32 - $n] {
+                    return None;
+                }
                 let mut bytes = Self::default();
                 bytes.copy_from_slice(&word[..$n]);
-                bytes
+                Some(bytes)
             }
         }
 
@@ -273,8 +276,8 @@ impl ToTopic for Bytes<Vec<u8>> {
 }
 
 impl FromTopic for Bytes<Vec<u8>> {
-    fn from_topic(_: Word) -> Self {
-        Self::default()
+    fn from_topic(_: Word) -> Option<Self> {
+        Some(Self::default())
     }
 }
 

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -157,7 +157,7 @@ where
     }
 
     fn decode(decoder: &mut Decoder) -> Result<Self, DecodeError> {
-        Ok(T::from_word(decoder.read_word()?))
+        T::from_word(decoder.read_word()?).ok_or(DecodeError::InvalidData)
     }
 }
 

--- a/src/function.rs
+++ b/src/function.rs
@@ -88,12 +88,16 @@ impl Primitive for ExternalFunction {
         word
     }
 
-    fn from_word(word: Word) -> Self {
+    fn from_word(word: Word) -> Option<Self> {
+        if word[24..] != [0; 8] {
+            return None;
+        }
+
         let mut address = Address::default();
         let mut selector = Selector(Default::default());
         address.copy_from_slice(&word[..20]);
         selector.0.copy_from_slice(&word[20..24]);
-        Self { address, selector }
+        Some(Self { address, selector })
     }
 }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -137,17 +137,17 @@ impl Value {
     pub fn from_word(kind: &ValueKind, word: Word) -> Option<Self> {
         match kind {
             ValueKind::Int(bit_width) => {
-                Some(Self::Int(Int(*bit_width, Primitive::from_word(word))))
+                Some(Self::Int(Int(*bit_width, Primitive::from_word(word)?)))
             }
             ValueKind::Uint(bit_width) => {
-                Some(Self::Uint(Uint(*bit_width, Primitive::from_word(word))))
+                Some(Self::Uint(Uint(*bit_width, Primitive::from_word(word)?)))
             }
-            ValueKind::Address => Some(Self::Address(Primitive::from_word(word))),
-            ValueKind::Bool => Some(Self::Bool(Primitive::from_word(word))),
+            ValueKind::Address => Some(Self::Address(Primitive::from_word(word)?)),
+            ValueKind::Bool => Some(Self::Bool(Primitive::from_word(word)?)),
             ValueKind::FixedBytes(byte_length) => {
                 Some(Self::FixedBytes(FixedBytes(*byte_length, word)))
             }
-            ValueKind::Function => Some(Self::Function(Primitive::from_word(word))),
+            ValueKind::Function => Some(Self::Function(Primitive::from_word(word)?)),
             _ => None,
         }
     }


### PR DESCRIPTION
Solidity ABI (specifically, starting with v2, which is automatically enabled for 0.8) does NOT allow extrenuous data in the padding/sign extending.

This PR modifies the decoder to no longer allow non-0 bytes (or non-0xff in the case of negative signed integers) to exist in the padding.